### PR TITLE
Use local shared package only

### DIFF
--- a/backend/Dockerfile-nlp.template
+++ b/backend/Dockerfile-nlp.template
@@ -13,6 +13,7 @@ COPY lambda_functions_nlp.py .
 COPY nlp ./nlp/
 COPY util ./util/
 COPY llm ./llm/
+COPY package/shared ./shared/
 
 # Install the Python dependencies and package them in a zip file
 RUN python3 -m pip install -r requirements.txt

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2340,11 +2340,8 @@ emoji = "^2.9.0"
 pydantic = "^2.5.3"
 
 [package.source]
-type = "git"
-url = "https://github.com/tobiaswaslowski/lingolift.git#bb17237"
-reference = "HEAD"
-resolved_reference = "bb172372e97909150dc5b658827bcc97c0b0261f"
-subdirectory = "shared"
+type = "directory"
+url = "../shared"
 
 [[package]]
 name = "shellingham"
@@ -3006,4 +3003,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.6"
-content-hash = "fcece62179e03e59bcb72df6e0254a0622d2b671a352393ed1872fdecfddf959"
+content-hash = "b2ae7d7ca33e0f2fb7cc18a7d46c1c32075cffbab6e4680f462f028109ea9663"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "3.11.6"
 python-iso639 = "^2024.1.2"
-shared = { git = "https://github.com/tobiaswaslowski/lingolift.git#bb17237", subdirectory = "shared" }
+shared = {path = "../shared"}
 
 [tool.poetry.group.generative.dependencies]
 openai = "^1.7.2"

--- a/frontend/poetry.lock
+++ b/frontend/poetry.lock
@@ -1565,11 +1565,8 @@ emoji = "^2.9.0"
 pydantic = "^2.5.3"
 
 [package.source]
-type = "git"
-url = "https://github.com/tobiaswaslowski/lingolift.git#bb17237"
-reference = "HEAD"
-resolved_reference = "eab2baa49351ed44bdf03e98b3ce8ff39dd0fedd"
-subdirectory = "shared"
+type = "directory"
+url = "../shared"
 
 [[package]]
 name = "six"
@@ -1953,4 +1950,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.18"
-content-hash = "fcb55cfe25878b0c0ae6ddf0852a7151ad8c6a0c452ef615fdf6d6542f9b0d1e"
+content-hash = "9c27bb476963888e01d0430e73d584a6a7dd64ec06c9e68ad3bf69dc00623e32"

--- a/frontend/pyproject.toml
+++ b/frontend/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.9.18"
 streamlit = "^1.30.0"
 pytest = "^7.4.4"
 mypy = "^1.8.0"
-shared = {git = "https://github.com/tobiaswaslowski/lingolift.git#bb17237", subdirectory = "shared"}
+shared = {path = "../shared"}
 
 
 [build-system]

--- a/shared/shared/model/inflection.py
+++ b/shared/shared/model/inflection.py
@@ -4,3 +4,8 @@ from pydantic import BaseModel
 class Inflection(BaseModel):
     word: str
     morphology: dict[str, str]
+
+
+class Inflections(BaseModel):
+    pos: str
+    inflections: list[Inflection]


### PR DESCRIPTION
The point here is that using a remote Github as the `shared` source has been a major source of inconvenience when developing, having to push incomplete changes, or change the source for development, or to pin specific versions in two-commit operations. This should smooth out the whole process.